### PR TITLE
add solution from rc-immediate for firefox sigil rendering issue

### DIFF
--- a/lib/src/lib/load.js
+++ b/lib/src/lib/load.js
@@ -2,12 +2,18 @@ import qr from 'qr-image';
 import { sigil, stringRenderer } from 'urbit-sigil-js';
 
 
-const loadImg = (base64, cb) => new Promise(resolve => {
-  const img = new Image();
-  img.onload = () => resolve(cb(img));
-  img.onerror = () => reject('Error loading image');
-  img.src = base64;
-});
+const loadImg = (base64, size) => {
+  return new Promise((resolve, reject) => {
+    let img = new Image();
+    img.width = size
+    img.height = size
+    img.addEventListener('load', e => resolve(img));
+    img.addEventListener('error', () => {
+      reject(new Error(`Failed to load image's data-url: ${base64}`));
+    });
+    img.src = base64;
+  });
+}
 
 
 
@@ -30,14 +36,23 @@ const loadQR = (size, data) => {
 
 const loadSigil = (size, patp) => {
   const svg = sigil({
-    patp,
-    renderer: stringRenderer,
     size: size,
-    colors: ['white', 'black'],
+    patp,
+    colors: ['black', 'white'],
+    renderer: stringRenderer,
   });
-  const svg64 = btoa(svg);
-  const image64 = DATA_URI_PREFIX + svg64;
-  return loadImg(image64, img => img);
+  // Old way it worked
+  // const svg64 = btoa(svg);
+  // const image64 = DATA_URI_PREFIX + svg64;
+  // The way it needs to work to support both Chrome and Firefox at the same time:
+  const svgDocument = new DOMParser().parseFromString(svg, 'image/svg+xml');
+  svgDocument.documentElement.width.baseVal.valueAsString = `${size}px`
+  svgDocument.documentElement.height.baseVal.valueAsString = `${size}px`
+  const base64EncodedSVG = btoa(
+    new XMLSerializer().serializeToString(svgDocument)
+  );
+
+  return loadImg(DATA_URI_PREFIX + base64EncodedSVG, size);
 }
 
 


### PR DESCRIPTION
- change loadSigil to support an 8 year old firefox bug
- update loadImage so that it actually `rejects` correctly