### PR TITLE
Feat/105 clean

### DIFF
--- a/lib/src/lib/draw.js
+++ b/lib/src/lib/draw.js
@@ -8,8 +8,17 @@ const sigil = (ctx, { data, x, y, size, type }) => {
   ctx.drawImage(data, x, y, size, size)
 }
 
-const img = (ctx, { data, x, y, width, height, type }) => {
-  ctx.drawImage(data, x, y + 3, height, width)
+const img = (ctx, { type, draw, data, path, width, height, x, y, color }) => {
+  // move img to correct xy pos
+  ctx.translate(x, y + 3)
+
+  // draw using svg path data
+  var path = new Path2D(data)
+  ctx.fillStyle = color
+  ctx.fill(path)
+
+  // reset translation by performing the inverse translation
+  ctx.translate(-x, -(y + 3))
 }
 
 const text = (

--- a/tools/elementSchema.js
+++ b/tools/elementSchema.js
@@ -25,8 +25,7 @@ const getSvgPath = (child) => {
       `Unable to get the path for the svg child: ${JSON.stringify(child)}`
     )
 
-  const ast = `<svg height="${child.absoluteBoundingBox.height}" width="${child.absoluteBoundingBox.width}"><path d="${path}"/></svg>`
-  return ast
+  return path
 }
 
 const rgba = (fills) => {
@@ -86,11 +85,11 @@ const img = (child, page) => {
     draw: 'img',
     data: getSvgPath(child),
     path: getPath(child),
-    // svg: getSvgPath(child),
     width: child.absoluteBoundingBox.height,
     height: child.absoluteBoundingBox.width,
     x: child.absoluteBoundingBox.x - page.originX,
     y: child.absoluteBoundingBox.y - page.originY,
+    color: rgba(child.fills),
   }
 }
 


### PR DESCRIPTION
1. change draw.js --> drawImg.  this func takes the svg path value and color.  it translates the starting point to the x & y value, then draws, then applies the inverse transformation to return the ctx translation to its original state.

2. change img elementSchema.  include color + change the data to only be the svg d value, not an svg tag 